### PR TITLE
Execute script command support

### DIFF
--- a/Winium/TestApp.StoreApps/TestApp.WindowsPhone/AutomationApi.cs
+++ b/Winium/TestApp.StoreApps/TestApp.WindowsPhone/AutomationApi.cs
@@ -1,0 +1,29 @@
+﻿namespace TestApp
+{
+    using System;
+
+    public class TestDto
+    {
+        public string Text { get; set; }
+
+        public long Value { get; set; }
+
+        public DateTime Date { get; set; }
+    }
+
+    // ReSharper disable UnusedMember.Global
+    public class AutomationApi
+    {
+        public static string Echo(string text)
+        {
+            return text;
+        }
+
+        public static TestDto ReturnStubState()
+        {
+            return new TestDto { Date = new DateTime(1985, 10, 21, 01, 20, 0), Text = "Flux", Value = 3 };
+        }
+    }
+
+    // ReSharper restore UnusedMember.Global
+}

--- a/Winium/TestApp.StoreApps/TestApp.WindowsPhone/TestApp.WindowsPhone.csproj
+++ b/Winium/TestApp.StoreApps/TestApp.WindowsPhone/TestApp.WindowsPhone.csproj
@@ -89,6 +89,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutomationApi.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>

--- a/Winium/TestApp.Test/py-functional/config.py
+++ b/Winium/TestApp.Test/py-functional/config.py
@@ -9,6 +9,6 @@ APPX_PATH = '..\\TestApp.StoreApps\\TestApp.WindowsPhone\\AppPackages\\TestApp.W
 
 DESIRED_CAPABILITIES = {
     "app": os.path.abspath(os.path.join(BASE_DIR, APPX_PATH)),
-    "deviceName": "Emulator 8.1"
-    # "debugConnectToRunningApp": True
+    "deviceName": "Emulator 8.1",
+    "debugConnectToRunningApp": False
 }

--- a/Winium/TestApp.Test/py-functional/config_silverlight.py
+++ b/Winium/TestApp.Test/py-functional/config_silverlight.py
@@ -8,5 +8,5 @@ AUT_PATH = r"..\TestApp.Silverlight\bin\{0}\TestApp_{0}_AnyCPU.xap".format(CONFI
 DESIRED_CAPABILITIES = {
     "deviceName": "Emulator 8.1",
     "app": os.path.abspath(os.path.join(BASE_DIR, AUT_PATH)),
-    # "debugConnectToRunningApp": True,
+    "debugConnectToRunningApp": False
 }

--- a/Winium/TestApp.Test/py-functional/tests/test_commands.py
+++ b/Winium/TestApp.Test/py-functional/tests/test_commands.py
@@ -181,6 +181,15 @@ class TestGetCommands(WuaTestCase):
         data = self.driver.pull_file(r"test\sample.dat")
         assert encoded == data
 
+    def test_execute_script_invoke_method_echo_with_arg(self):
+        rv = self.driver.execute_script('mobile: invokeMethod', 'TestApp.AutomationApi, TestApp.WindowsPhone', 'Echo', 'blah blah')
+        assert 'blah blah' == rv
+
+    def test_execute_script_invoke_method_complex_return_value_no_args(self):
+        expected = {u'Date': u'1985-10-21T01:20:00', u'Text': u'Flux', u'Value': 3}
+        rv = self.driver.execute_script('mobile: invokeMethod', 'TestApp.AutomationApi, TestApp.WindowsPhone', 'ReturnStubState')
+        assert expected == rv
+
 
 class UsesSecondTab(WuaTestCase):
     @pytest.fixture

--- a/Winium/TestApp.Test/py-functional/tests_silverlight/test_commands.py
+++ b/Winium/TestApp.Test/py-functional/tests_silverlight/test_commands.py
@@ -173,6 +173,28 @@ class TestGetCommands(SilverlightTestCase):
         assert expected == rv
 
 
+class TestExecuteScript(SilverlightTestCase):
+    __shared_session__ = False
+
+    @pytest.mark.parametrize("command_alias", ["automation: InvokePattern.Invoke"])
+    def test_automation_invoke(self, command_alias):
+        self.driver.find_element_by_id('MyTextBox').send_keys('')
+        element = self.driver.find_element_by_id('SetButton')
+        self.driver.execute_script(command_alias, element)
+        assert 'CARAMBA' == self.driver.find_element_by_id('MyTextBox').text
+
+    @pytest.mark.parametrize("command_alias", ["automation: ScrollPattern.Scroll"])
+    def test_automation_scroll(self, command_alias):
+        list_box = self.driver.find_element_by_id('MyListBox')
+        list_item = list_box.find_element_by_name('November')
+        start_location = list_item.location
+        scroll_info = {"v": "smallIncrement", "count": 10}
+        self.driver.execute_script(command_alias, list_box, scroll_info)
+        end_location = list_item.location
+
+        assert (end_location['y'] - start_location['y']) < 0
+
+
 class TestBasicInput(SilverlightTestCase):
     __shared_session__ = False
 

--- a/Winium/Winium.Mobile.Common/ExtendedCommand.cs
+++ b/Winium/Winium.Mobile.Common/ExtendedCommand.cs
@@ -5,6 +5,9 @@ namespace Winium.Mobile.Common
         #region Static Fields
 
         public static readonly string InvokeAppBarItemCommand = "invokeAppBarItem";
+
+        public static readonly string InvokeMethodCommand = "invokeMethod";
+
         #endregion
     }
 }

--- a/Winium/Winium.Mobile.Driver/CommandExecutors/ExecuteScriptExecutor.cs
+++ b/Winium/Winium.Mobile.Driver/CommandExecutors/ExecuteScriptExecutor.cs
@@ -78,7 +78,7 @@
                 parameters["args"] = new JArray(args);
             }
 
-            var invokeCommand = new Command(DriverCommand.ExecuteScript, parameters);
+            var invokeCommand = new Command(ExtendedDriverCommand.InvokeMethodCommand, parameters);
             var response = this.Automator.CommandForwarder.ForwardCommand(invokeCommand);
             var rv = JsonConvert.DeserializeObject<JsonResponse>(response);
             if (rv.Status != ResponseStatus.Success)

--- a/Winium/Winium.Silverlight.InnerServer/Automator.cs
+++ b/Winium/Winium.Silverlight.InnerServer/Automator.cs
@@ -131,6 +131,10 @@
             {
                 commandToExecute = new GetElementAttributeCommand { ElementId = elementId };
             }
+            else if (command.Equals(DriverCommand.ExecuteScript))
+            {
+                commandToExecute = new ExecuteCommand();
+            }
             else if (command.Equals(ExtendedDriverCommand.InvokeAppBarItemCommand))
             {
                 commandToExecute = new InvokeAppBarItemCommand();

--- a/Winium/Winium.Silverlight.InnerServer/Automator.cs
+++ b/Winium/Winium.Silverlight.InnerServer/Automator.cs
@@ -135,9 +135,9 @@
             {
                 commandToExecute = new InvokeAppBarItemCommand();
             }
-            else if (command.Equals(DriverCommand.ExecuteScript))
+            else if (command.Equals(ExtendedDriverCommand.InvokeMethodCommand))
             {
-                commandToExecute = new ExecuteScriptCommand();
+                commandToExecute = new InvokeMethodCommand();
             }
             else
             {

--- a/Winium/Winium.Silverlight.InnerServer/Commands/ExecuteCommand.cs
+++ b/Winium/Winium.Silverlight.InnerServer/Commands/ExecuteCommand.cs
@@ -1,21 +1,19 @@
-﻿namespace Winium.StoreApps.InnerServer.Commands
+﻿namespace Winium.Silverlight.InnerServer.Commands
 {
     #region
 
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Windows;
+    using System.Windows.Automation;
+    using System.Windows.Automation.Peers;
+    using System.Windows.Automation.Provider;
 
     using Newtonsoft.Json.Linq;
 
-    using Windows.UI.Xaml;
-    using Windows.UI.Xaml.Automation;
-    using Windows.UI.Xaml.Automation.Peers;
-    using Windows.UI.Xaml.Automation.Provider;
-
     using Winium.Mobile.Common;
     using Winium.Mobile.Common.Exceptions;
-    using Winium.StoreApps.InnerServer.Commands.Helpers;
 
     #endregion
 
@@ -40,7 +38,7 @@
 
         #region Public Methods and Operators
 
-        protected override string DoImpl()
+        public override string DoImpl()
         {
             string command;
             var prefix = string.Empty;
@@ -63,9 +61,6 @@
             {
                 case "automation:":
                     response = this.ExecuteAutomationScript(command);
-                    break;
-                case "attribute:":
-                    response = this.ExecuteAttributeScript(command);
                     break;
                 default:
                     var msg = string.Format(HelpUnknownScriptMsg, prefix, command, HelpUrlScript);
@@ -158,37 +153,10 @@
             return peer.IsOffscreen();
         }
 
-        private string ExecuteAttributeScript(string command)
-        {
-            if (command != "set")
-            {
-                var msg = string.Format(HelpUnknownScriptMsg, "attribute:", command, HelpUrlAttributeScript);
-                throw new AutomationException(msg, ResponseStatus.JavaScriptError);
-            }
-
-            /* 'attribute: set' is used to set property value on element
-             * script parameters:
-             *      element - WebElement on wich attribute will be set
-             *      attribute name - property to be set, nested property can be set using dot syntax
-             *      value - value to be set
-             */
-            var args = (JArray)this.Parameters["args"];
-
-            var elementId = args[0]["ELEMENT"].ToString();
-            var element = this.Automator.ElementsRegistry.GetRegisteredElement(elementId);
-
-            var attributeName = args[1].ToString();
-            var value = args[2];
-
-            element.SetProperty(attributeName, value);
-
-            return null;
-        }
-
         private object ExecuteAutomationScript(string command)
         {
             var elementId = ((JArray)this.Parameters["args"])[0]["ELEMENT"].ToString();
-            var element = this.Automator.ElementsRegistry.GetRegisteredElement(elementId).Element;
+            var element = this.Automator.WebElements.GetRegisteredElement(elementId);
 
             switch (command)
             {

--- a/Winium/Winium.Silverlight.InnerServer/Commands/FrameworkElementExtensions.cs
+++ b/Winium/Winium.Silverlight.InnerServer/Commands/FrameworkElementExtensions.cs
@@ -4,8 +4,11 @@
     using System.Linq;
     using System.Windows;
     using System.Windows.Automation;
+    using System.Windows.Automation.Peers;
     using System.Windows.Controls;
     using System.Windows.Media;
+
+    using Winium.Mobile.Common.Exceptions;
 
     internal static class FrameworkElementExtensions
     {
@@ -128,6 +131,37 @@
 
                 element = container;
             }
+        }
+
+        internal static AutomationPeer GetAutomationPeer(this FrameworkElement element)
+        {
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(element);
+            if (peer == null)
+            {
+                throw new AutomationException("Element does not support AutomationPeer.");
+            }
+
+            return peer;
+        }
+
+        internal static T GetProviderOrDefault<T>(this FrameworkElement element, PatternInterface patternInterface)
+            where T : class
+        {
+            var peer = GetAutomationPeer(element);
+
+            return peer == null ? null : peer.GetPattern(patternInterface) as T;
+        }
+
+        internal static T GetProvider<T>(this FrameworkElement element, PatternInterface patternInterface)
+            where T : class
+        {
+            var provider = element.GetProviderOrDefault<T>(patternInterface);
+            if (provider != null)
+            {
+                return provider;
+            }
+
+            throw new AutomationException(string.Format("Element does not support {0} control pattern interface.", typeof(T).Name));
         }
 
         #endregion

--- a/Winium/Winium.Silverlight.InnerServer/Commands/InvokeMethodCommand.cs
+++ b/Winium/Winium.Silverlight.InnerServer/Commands/InvokeMethodCommand.cs
@@ -3,30 +3,30 @@
     using System;
     using System.Linq;
 
-    using Winium.Mobile.Common;
-
     using Newtonsoft.Json.Linq;
 
-    internal class ExecuteScriptCommand : CommandBase
+    using Winium.Mobile.Common;
+
+    internal class InvokeMethodCommand : CommandBase
     {
         public override string DoImpl()
         {
             JToken typeParam;
             if (!this.Parameters.TryGetValue("type", out typeParam))
             {
-                return "specify fully qualified type name in 'type' parameter";
+                return this.JsonResponse(ResponseStatus.JavaScriptError, "specify fully qualified type name in 'type' parameter");
             }
 
             JToken methodParam;
             if (!this.Parameters.TryGetValue("method", out methodParam))
             {
-                return "specify fully qualified type name in 'method' parameter";
+                return this.JsonResponse(ResponseStatus.JavaScriptError, "specify fully qualified type name in 'method' parameter");
             }
 
             JToken argsParam;
             var args = this.Parameters.TryGetValue("args", out argsParam)
-                                ? ((JArray)argsParam).ToObject<object[]>()
-                                : new object[] { };
+                           ? ((JArray)argsParam).ToObject<object[]>()
+                           : new object[] { };
 
             var typeName = typeParam.ToString();
             var type = FindType(typeName);

--- a/Winium/Winium.Silverlight.InnerServer/Winium.Silverlight.InnerServer.csproj
+++ b/Winium/Winium.Silverlight.InnerServer/Winium.Silverlight.InnerServer.csproj
@@ -98,6 +98,7 @@
     <Compile Include="AcceptedRequest.cs" />
     <Compile Include="Automator.cs" />
     <Compile Include="AutomatorElements.cs" />
+    <Compile Include="Commands\ExecuteCommand.cs" />
     <Compile Include="Commands\InvokeMethodCommand.cs" />
     <Compile Include="Commands\GetElementSizeCommand.cs" />
     <Compile Include="Commands\GetElementRectCommand.cs" />

--- a/Winium/Winium.Silverlight.InnerServer/Winium.Silverlight.InnerServer.csproj
+++ b/Winium/Winium.Silverlight.InnerServer/Winium.Silverlight.InnerServer.csproj
@@ -98,7 +98,7 @@
     <Compile Include="AcceptedRequest.cs" />
     <Compile Include="Automator.cs" />
     <Compile Include="AutomatorElements.cs" />
-    <Compile Include="Commands\ExecuteScriptCommand.cs" />
+    <Compile Include="Commands\InvokeMethodCommand.cs" />
     <Compile Include="Commands\GetElementSizeCommand.cs" />
     <Compile Include="Commands\GetElementRectCommand.cs" />
     <Compile Include="Public\ClickableApplicationBarMenuItem.cs" />

--- a/Winium/Winium.StoreApps.InnerServer/Automator.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Automator.cs
@@ -161,6 +161,10 @@
             {
                 commandToExecute = new CloseAppCommand();
             }
+            else if (command.Equals(ExtendedDriverCommand.InvokeMethodCommand))
+            {
+                commandToExecute = new InvokeMethodCommand();
+            }
             else
             {
                 throw new NotImplementedException("Not implemented: " + command);

--- a/Winium/Winium.StoreApps.InnerServer/Commands/Helpers/FrameworkElementExtensions.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Commands/Helpers/FrameworkElementExtensions.cs
@@ -37,7 +37,7 @@
 
         internal static AutomationPeer GetAutomationPeer(this FrameworkElement element)
         {
-            var peer = FrameworkElementAutomationPeer.FromElement(element);
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(element);
             if (peer == null)
             {
                 throw new AutomationException("Element does not support AutomationPeer.");
@@ -49,7 +49,7 @@
         internal static T GetProviderOrDefault<T>(this FrameworkElement element, PatternInterface patternInterface)
             where T : class
         {
-            var peer = FrameworkElementAutomationPeer.FromElement(element);
+            var peer = GetAutomationPeer(element);
 
             return peer == null ? null : peer.GetPattern(patternInterface) as T;
         }

--- a/Winium/Winium.StoreApps.InnerServer/Commands/InvokeMethodCommand.cs
+++ b/Winium/Winium.StoreApps.InnerServer/Commands/InvokeMethodCommand.cs
@@ -1,0 +1,46 @@
+﻿namespace Winium.StoreApps.InnerServer.Commands
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+
+    using Newtonsoft.Json.Linq;
+
+    using Winium.Mobile.Common;
+
+    internal class InvokeMethodCommand : CommandBase
+    {
+        protected override string DoImpl()
+        {
+            JToken typeParam;
+            if (!this.Parameters.TryGetValue("type", out typeParam))
+            {
+                return this.JsonResponse(ResponseStatus.JavaScriptError, "specify fully qualified type name in 'type' parameter");
+            }
+
+            JToken methodParam;
+            if (!this.Parameters.TryGetValue("method", out methodParam))
+            {
+                return this.JsonResponse(ResponseStatus.JavaScriptError, "specify fully qualified type name in 'method' parameter");
+            }
+
+            JToken argsParam;
+            var args = this.Parameters.TryGetValue("args", out argsParam)
+                           ? ((JArray)argsParam).ToObject<object[]>()
+                           : new object[] { };
+
+            var typeName = typeParam.ToString();
+            var type = Type.GetType(typeName);
+
+            if (type == null)
+            {
+                return this.JsonResponse(ResponseStatus.JavaScriptError, string.Format("type '{0}' not found", type));
+            }
+
+            var method = methodParam.ToString();
+            var rv = type.GetRuntimeMethods().Single(x => x.Name == method).Invoke(null, args);
+
+            return this.JsonResponse(ResponseStatus.Success, rv);
+        }
+    }
+}

--- a/Winium/Winium.StoreApps.InnerServer/Winium.StoreApps.InnerServer.csproj
+++ b/Winium/Winium.StoreApps.InnerServer/Winium.StoreApps.InnerServer.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Commands\GetElementSizeCommand.cs" />
     <Compile Include="Commands\Helpers\ControlExtensions.cs" />
     <Compile Include="Commands\Helpers\IDictionaryExtensions.cs" />
+    <Compile Include="Commands\InvokeMethodCommand.cs" />
     <Compile Include="Commands\IsElementEnabledCommand.cs" />
     <Compile Include="ElementsRegistry.cs" />
     <Compile Include="Commands\AlertCommand.cs" />


### PR DESCRIPTION
Fixes #175 and converges major part of `ExecuteScript` functionality of StoreApps and Silverlight versions.

- Add `mobile: invokeMethod` sub-command support to StoreApps (already supported in Silverlight). This enables calling any public static method in AUT from tests
  ```py
  self.driver.execute_script('mobile: invokeMethod', 'TestApp.AutomationApi, TestApp.WindowsPhone', 'Echo', 'blah blah')
  ```
  > Note: StoreApps requires specifying fully qualified class name and assembly name separated by comma. Silverlight (at the moment) does not require specifying assembly name.
- Add following `automation` sub-commands to Silverlight (already supported by StoreApps). See [wiki](https://github.com/2gis/Winium.Mobile/wiki/Command-Execute-Script#use-automationpeerspatterninterface-on-element)
  - `automation: InvokePattern.Invoke`,
  - `automation: ScrollPattern.Scroll`,
  - `automation: TogglePattern.Toggle`,
  - `automation: TogglePattern.ToggleState`,
  - `automation: GetClickablePoint`,
  - `automation: IsOffscreen`

> Note that `attribute` sub-commands are still supported by StoreApps only.